### PR TITLE
Build new releases for electron v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "gypfile": true,
   "dependencies": {
     "nan": "^2.0.5",
-    "node-gyp-build": "^3.3.0"
+    "node-gyp-build": "^4.2.3"
   },
   "scripts": {
     "vendor": "git clone https://github.com/orlp/ed25519 vendor/ed25519",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/substack/ed25519-supercop#readme",
   "devDependencies": {
-    "prebuildify": "^2.6.1",
+    "prebuildify": "^4.0.0",
     "tape": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ed25519-supercop",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ed25519 curve operations using a supercop/ref10 implementation",
   "main": "index.js",
   "gypfile": true,


### PR DESCRIPTION
This PR bumps dependencies and requests to set up builds to support electronjs v9.* for mac, linux and win